### PR TITLE
feat(ui): highlight winning positions

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -20,8 +20,4 @@ jobs:
         run: yarn test        
       - name: Build the app
         run: yarn build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_HALOGEN_BYTE_345804 }}'
-          projectId: halogen-byte-345804
+

--- a/libs/core/application/src/lib/services/game-logic.impl.ts
+++ b/libs/core/application/src/lib/services/game-logic.impl.ts
@@ -6,6 +6,7 @@ import {
   SymbolMarker,
   evaluateOutcome,
   evaluateStatus,
+  getWinCombination,
   playerWon,
 } from '@tictac/domain'
 import { inject, injectable } from 'inversify'
@@ -94,6 +95,20 @@ export class GameLogicImpl implements GameLogic {
         gameStatus
       ),
     }
+  }
+
+  /**
+   * Returns the winning positions on the tic-tac-toe board, if any.
+   * The winning positions represent the row, column, or diagonal that forms a winning combination.
+   *
+   * @param board The tic-tac-toe board represented as a 2D array of strings.
+   *              Each element represents the value at a specific cell on the board.
+   *              An empty string represents an empty cell.
+   * @return The winning positions as an array of arrays, where each inner array contains the row and column indices.
+   *         Returns `null` if there are no winning combinations on the board.
+   */
+  getWinPositions(board: string[][]): number[][] | null {
+    return getWinCombination(board)
   }
 
   /**

--- a/libs/core/domain/src/lib/algorithms/minimax.spec.ts
+++ b/libs/core/domain/src/lib/algorithms/minimax.spec.ts
@@ -1,5 +1,5 @@
 import { GameOutcome, GameStatus, SymbolMarker } from '../models'
-import { boardEmpty, boardFilled, evaluateOutcome, evaluateStatus, findBestMove, playerDraw, playerWon } from './minimax'
+import { boardEmpty, boardFilled, evaluateOutcome, evaluateStatus, findBestMove, getWinCombination, playerDraw, playerWon } from './minimax'
 describe('minimax', () => {
     describe('evaluateOutcome', () => {
         it('should evaluate as X win horizontal', () => {
@@ -319,6 +319,52 @@ describe('minimax', () => {
                 ["X", "X", "O"]
             ]
             expect(boardFilled(board)).toEqual(true)
+        })
+    })
+    describe('getWinCombination', () => {
+        it('should return null if no win combination', () => {
+            const board = [
+                ['X', 'O', 'X'],
+                ['X', 'O', 'X'],
+                ['O', 'X', 'O']
+            ]
+            expect(getWinCombination(board)).toEqual(null)
+        })
+        it('should return win combination horizontal', () => {
+            const board = [
+                ['X', 'X', 'X'],
+                ['O', 'O', 'X'],
+                ['X', 'X', 'O']
+            ]
+            expect(getWinCombination(board)).toEqual([
+                [0,0],
+                [0,1],
+                [0,2]
+            ])
+        })
+        it('should return win combination vertical', () => {
+            const board = [
+                ['X', 'O', 'O'],
+                ['O', 'O', 'X'],
+                ['X', 'O', 'X']
+            ]
+            expect(getWinCombination(board)).toEqual([
+                [0,1],
+                [1,1],
+                [2,1]
+            ])
+        })
+        it('should return win combination diagonal', () => {
+            const board = [
+                ['X', 'O', 'O'],
+                ['O', 'X', 'O'],
+                ['X', 'O', 'X']
+            ]
+            expect(getWinCombination(board)).toEqual([
+                [0,0],
+                [1,1],
+                [2,2]
+            ])
         })
     })
 })

--- a/libs/core/domain/src/lib/algorithms/minimax.ts
+++ b/libs/core/domain/src/lib/algorithms/minimax.ts
@@ -1,11 +1,11 @@
-import { GameOutcome, GameStatus, Move, SymbolMarker } from "../models";
+import { GameOutcome, GameStatus, Move, SymbolMarker } from '../models'
 
 /**
  * The minimax algorithm is a decision-making algorithm used in game theory and AI that helps determine the best move for a player by
  * considering all possible future moves and their outcomes. At each turn, the AI player recursively explores the game tree to
- * find the optimal move that maximizes its chances of winning or minimizes the opponent's chances of winning. 
- * 
- * Sources: 
+ * find the optimal move that maximizes its chances of winning or minimizes the opponent's chances of winning.
+ *
+ * Sources:
  *     https://www.neverstopbuilding.com/blog/minimax
  */
 
@@ -15,27 +15,47 @@ import { GameOutcome, GameStatus, Move, SymbolMarker } from "../models";
  * @returns {GameOutcome} The outcome of the game.
  */
 export const evaluateOutcome = (board: string[][]) => {
+  const winCombination = getWinCombination(board)
+  if (winCombination) {
+    const [row, cell] = winCombination[0]
+    return board[row][cell] === SymbolMarker.X
+        ? GameOutcome.X_WINS
+        : GameOutcome.O_WINS
+  }
+
+  if (board.every((row) => row.every((cell) => cell))) {
+    return GameOutcome.DRAW
+  }
+
+  return GameOutcome.IN_PROGRESS
+}
+
+export const getWinCombination = (board: string[][]): number[][] | null => {
   // Winning combinations
   const winCombinations: number[][] = [
     [0, 1, 2], [3, 4, 5], [6, 7, 8], // Rows
     [0, 3, 6], [1, 4, 7], [2, 5, 8], // Columns
     [0, 4, 8], [2, 4, 6] // Diagonals
   ];
-
   for (const combination of winCombinations) {
-    const [a, b, c] = combination;
-    if (board[Math.floor(a / 3)][a % 3] &&
-        board[Math.floor(a / 3)][a % 3] === board[Math.floor(b / 3)][b % 3] &&
-        board[Math.floor(b / 3)][b % 3] === board[Math.floor(c / 3)][c % 3]) {
-      return board[Math.floor(a / 3)][a % 3] === SymbolMarker.X ? GameOutcome.X_WINS : GameOutcome.O_WINS;
+    const [a, b, c] = combination
+    const [rowA, colA] = [Math.floor(a / 3), a % 3]
+    const [rowB, colB] = [Math.floor(b / 3), b % 3]
+    const [rowC, colC] = [Math.floor(c / 3), c % 3]
+
+    if (
+      board[rowA][colA] &&
+      board[rowA][colA] === board[rowB][colB] &&
+      board[rowA][colA] === board[rowC][colC]
+    ) {
+      return [
+        [rowA, colA],
+        [rowB, colB],
+        [rowC, colC],
+      ]
     }
   }
-
-  if (board.every(row => row.every(cell => cell))) {
-    return GameOutcome.DRAW;
-  }
-
-  return GameOutcome.IN_PROGRESS;
+  return null
 }
 
 /**
@@ -44,21 +64,22 @@ export const evaluateOutcome = (board: string[][]) => {
  * @param {SymbolMarker} symbol - The symbol of the current player.
  * @returns {GameStatus} The status of the game.
  */
-export const evaluateStatus = (board: string[][], symbol: SymbolMarker) => {    
-    const otherSymbol = symbol === SymbolMarker.X ? SymbolMarker.O : SymbolMarker.X
-    if (playerDraw(board)) {
-        return GameStatus.DRAW
-    }
-    if (playerWon(board, symbol)) {
-        return GameStatus.WIN
-    }
-    if (playerWon(board, otherSymbol)) {
-        return GameStatus.LOSE
-    }
-    if (boardEmpty(board)) {
-        return GameStatus.INITIAL
-    }
-    return GameStatus.IN_PROGRESS
+export const evaluateStatus = (board: string[][], symbol: SymbolMarker) => {
+  const otherSymbol =
+    symbol === SymbolMarker.X ? SymbolMarker.O : SymbolMarker.X
+  if (playerDraw(board)) {
+    return GameStatus.DRAW
+  }
+  if (playerWon(board, symbol)) {
+    return GameStatus.WIN
+  }
+  if (playerWon(board, otherSymbol)) {
+    return GameStatus.LOSE
+  }
+  if (boardEmpty(board)) {
+    return GameStatus.INITIAL
+  }
+  return GameStatus.IN_PROGRESS
 }
 
 /**
@@ -68,13 +89,19 @@ export const evaluateStatus = (board: string[][], symbol: SymbolMarker) => {
  * @returns {boolean} True if the player has won, false otherwise.
  */
 export const playerWon = (board: string[][], symbol: SymbolMarker) => {
-    if (symbol === SymbolMarker.O && evaluateOutcome(board) === GameOutcome.O_WINS) {
-        return true
-    }
-    if (symbol === SymbolMarker.X && evaluateOutcome(board) === GameOutcome.X_WINS) {
-        return true
-    }
-    return false
+  if (
+    symbol === SymbolMarker.O &&
+    evaluateOutcome(board) === GameOutcome.O_WINS
+  ) {
+    return true
+  }
+  if (
+    symbol === SymbolMarker.X &&
+    evaluateOutcome(board) === GameOutcome.X_WINS
+  ) {
+    return true
+  }
+  return false
 }
 
 /**
@@ -83,14 +110,13 @@ export const playerWon = (board: string[][], symbol: SymbolMarker) => {
  * @returns {boolean} True if the game ended in a draw, false otherwise.
  */
 export const playerDraw = (board: string[][]) => {
-    if (!boardFilled(board)) {
-        return false
-    }
-    if (playerWon(board, SymbolMarker.X) ||
-        playerWon(board, SymbolMarker.O)) {
-        return false
-    }
-    return true
+  if (!boardFilled(board)) {
+    return false
+  }
+  if (playerWon(board, SymbolMarker.X) || playerWon(board, SymbolMarker.O)) {
+    return false
+  }
+  return true
 }
 
 /**
@@ -99,9 +125,8 @@ export const playerDraw = (board: string[][]) => {
  * @returns {boolean} True if the board is empty, false otherwise.
  */
 export const boardEmpty = (board: string[][]) => {
-    return board.every(row => row.every(cell => !cell))
+  return board.every((row) => row.every((cell) => !cell))
 }
-
 
 /**
  * Checks if the board is filled (all cells are filled).
@@ -109,10 +134,10 @@ export const boardEmpty = (board: string[][]) => {
  * @returns {boolean} True if the board is filled, false otherwise.
  */
 export const boardFilled = (board: string[][]) => {
-    if (board.every(row => row.every(cell => cell))) {
-        return true
-    }
-    return false
+  if (board.every((row) => row.every((cell) => cell))) {
+    return true
+  }
+  return false
 }
 
 /**
@@ -123,9 +148,12 @@ export const boardFilled = (board: string[][]) => {
  * @param {SymbolMarker} options.aiPlayer - The symbol of the AI player.
  * @returns {Move} The best move for the AI player.
  */
-export const findBestMove = (board: string[][], options: { humanPlayer: SymbolMarker, aiPlayer: SymbolMarker}) => {
-    const bestMove = minimax(board, options.aiPlayer, options)
-    return bestMove
+export const findBestMove = (
+  board: string[][],
+  options: { humanPlayer: SymbolMarker; aiPlayer: SymbolMarker }
+) => {
+  const bestMove = minimax(board, options.aiPlayer, options)
+  return bestMove
 }
 
 /**
@@ -137,56 +165,59 @@ export const findBestMove = (board: string[][], options: { humanPlayer: SymbolMa
  * @param {SymbolMarker} options.aiPlayer - The symbol of the AI player.
  * @returns {Move} The best move for the player.
  */
-export const minimax = (board: string[][], player: SymbolMarker, options: { humanPlayer: SymbolMarker, aiPlayer: SymbolMarker }): Move => {
-    if (playerWon(board, options.aiPlayer)) {
-        return { score: 1 }
-    }
-    if (playerWon(board, options.humanPlayer)) {
-        return { score: -1 }
-    }
-    if (playerDraw(board)) {
-        return { score: 0 }
-    }
+export const minimax = (
+  board: string[][],
+  player: SymbolMarker,
+  options: { humanPlayer: SymbolMarker; aiPlayer: SymbolMarker }
+): Move => {
+  if (playerWon(board, options.aiPlayer)) {
+    return { score: 1 }
+  }
+  if (playerWon(board, options.humanPlayer)) {
+    return { score: -1 }
+  }
+  if (playerDraw(board)) {
+    return { score: 0 }
+  }
 
-    const moves = []
-    for (let row = 0; row < 3; row++) {
-        for (let col = 0; col < 3; col++) {
-            if (!board[row][col]) {
-                let move = {} as Move
-                const newBoard = [...board.map(row => [...row])]; 
-                newBoard[row][col] = player;
+  const moves = []
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 3; col++) {
+      if (!board[row][col]) {
+        let move = {} as Move
+        const newBoard = [...board.map((row) => [...row])]
+        newBoard[row][col] = player
 
-                if (player == options.aiPlayer){
-                    move = minimax(newBoard, options.humanPlayer, options);
-                    move.position = [row, col]
-                }
-                else{
-                    move = minimax(newBoard, options.aiPlayer, options);
-                    move.position = [row, col]
-                }
-                moves.push(move)
-            }
+        if (player == options.aiPlayer) {
+          move = minimax(newBoard, options.humanPlayer, options)
+          move.position = [row, col]
+        } else {
+          move = minimax(newBoard, options.aiPlayer, options)
+          move.position = [row, col]
         }
+        moves.push(move)
+      }
     }
+  }
 
-    let bestMove: Move  = { score: -1 }
-    if (player === options.aiPlayer) {
-        let bestScore = -Infinity;
-        for(let i = 0; i < moves.length; i++){
-            if(moves[i].score > bestScore){
-              bestScore = moves[i].score;
-              bestMove = moves[i];
-            }
-        }
-    } else {
-        let bestScore = Infinity
-        for(let i = 0; i < moves.length; i++){
-            if(moves[i].score < bestScore){
-                bestScore = moves[i].score;
-                bestMove = moves[i]
-              }
-        }
+  let bestMove: Move = { score: -1 }
+  if (player === options.aiPlayer) {
+    let bestScore = -Infinity
+    for (let i = 0; i < moves.length; i++) {
+      if (moves[i].score > bestScore) {
+        bestScore = moves[i].score
+        bestMove = moves[i]
+      }
     }
+  } else {
+    let bestScore = Infinity
+    for (let i = 0; i < moves.length; i++) {
+      if (moves[i].score < bestScore) {
+        bestScore = moves[i].score
+        bestMove = moves[i]
+      }
+    }
+  }
 
-    return bestMove
+  return bestMove
 }

--- a/libs/delivery/ui/src/lib/components/board/board.tsx
+++ b/libs/delivery/ui/src/lib/components/board/board.tsx
@@ -1,10 +1,10 @@
 import { GameBoard, TYPES } from '@tictac/application'
-import { GameState, GameStatus, SymbolMarker } from '@tictac/domain'
+import { GameState, GameStatus, SymbolMarker, getWinCombination } from '@tictac/domain'
 import { useInjection } from 'inversify-react'
 import { useSelector } from 'react-redux'
 import { AppState } from '../../models/app-state'
 import { moveToSquare, store } from '../../store'
-import Square from '../square/square'
+import Square, { SquareStatus } from '../square/square'
 
 function Board() {
   const gameBoard = useInjection<GameBoard>(TYPES.GameBoard)
@@ -34,14 +34,22 @@ function Board() {
     return true
   }
   function renderCell(position: [number, number]) {
+    let squareStatus = SquareStatus.NORMAL
     if (gameState.status === GameStatus.INITIAL) {
       return ''
+    }
+    if (gameState.done) {
+      const winCombination = getWinCombination(gameState.gameBoardState.positions) || [];
+      squareStatus = winCombination.some(([x, y]) => x === position[0] && y === position[1])
+        ? SquareStatus.HIGHLIGHT
+        : SquareStatus.DIMMED;
     }
     return (
       <Square
         enabled={isEnabled(position)}
         position={position}
         value={SymbolMarker.X}
+        status={squareStatus}
         onClick={() => clickSquare(position)}
       />
     )

--- a/libs/delivery/ui/src/lib/components/modal/modal.tsx
+++ b/libs/delivery/ui/src/lib/components/modal/modal.tsx
@@ -3,21 +3,21 @@ import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router'
 import { AppState, SettingsState } from '../../models'
 import { backToMenu, startNextGame, store } from '../../store'
+import { useEffect, useState } from 'react'
 
 function Modal() {
   const navigate = useNavigate()
-  const settingsState = useSelector<AppState, SettingsState>(
-    (state: AppState) => state.settings
-  )
-  const gameState = useSelector<AppState, GameState>(
-    (state: AppState) => state.game
-  )
-  const status = gameState.status
+  const [showModal, setShowModal] = useState(false) // State to control modal visibility
+  const { multiplayer, winner, status } = useSelector<AppState, GameState & SettingsState>((state: AppState) => ({
+    ...state.settings,
+    ...state.game
+  }));
 
   let title = ''
   let message = ''
   let iconColor = ''
-  if (!settingsState.multiplayer) {
+
+  if (!multiplayer) {
     if (status === GameStatus.WIN) {
       title = 'Victory!'
       message = 'Congratulations on your well-deserved victory!'
@@ -32,8 +32,8 @@ function Modal() {
       iconColor = 'bg-gray-100'
     }
   } else {
-    if (gameState.winner) {
-      title = `${gameState.winner.name} Victory!`
+    if (winner) {
+      title = `${winner.name} Victory!`
       message = 'Congratulations on your well-deserved victory!'
       iconColor = 'bg-green-100'
     }
@@ -43,8 +43,22 @@ function Modal() {
       iconColor = 'bg-gray-100'
     }
   }
+  useEffect(() => {
+    if (message) {
+      if (status !== GameStatus.DRAW) {
+        // Delay showing the modal after 1 second
+        const timeoutId = setTimeout(() => {
+          setShowModal(true);
+        }, 1000);
+        return () => clearTimeout(timeoutId);
+      } else {
+        setShowModal(true);
+      }
+    }
+  }, [message, status]);
 
   function handleNextGame() {
+    setShowModal(false)
     store.dispatch(startNextGame())
   }
   function handleBackToMenu() {
@@ -53,7 +67,7 @@ function Modal() {
   }
 
   function getIcon() {
-    if (!settingsState.multiplayer) {
+    if (!multiplayer) {
       if (status === GameStatus.WIN) {
         return (
           <svg
@@ -111,7 +125,7 @@ function Modal() {
         )
       }
     } else {
-      if (gameState.winner) {
+      if (winner) {
         return (
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -153,7 +167,7 @@ function Modal() {
   }
 
   return (
-    <div className={message ? '' : 'hidden'}>
+    <div className={`modal ${showModal ? '' : 'hidden'}`}>
       <div
         className="relative z-10"
         aria-labelledby="modal-title"

--- a/libs/delivery/ui/src/lib/components/square/square.scss
+++ b/libs/delivery/ui/src/lib/components/square/square.scss
@@ -1,0 +1,12 @@
+@keyframes spin-horizontal {
+    0% {
+      transform: rotateY(0);
+    }
+    100% {
+      transform: rotateY(360deg);
+    }
+  }
+  
+  .animate-spin-vertical {
+    animation: spin-horizontal 2s linear infinite;
+  }

--- a/libs/delivery/ui/src/lib/components/square/square.tsx
+++ b/libs/delivery/ui/src/lib/components/square/square.tsx
@@ -2,10 +2,24 @@ import { GameState, SymbolMarker } from '@tictac/domain'
 import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { AppState } from '../../models/app-state'
+import './square.scss'
+ 
+export enum SquareStatus {
+  NORMAL = 'NORMAL',
+  HIGHLIGHT = 'HIGHLIGHT',
+  DIMMED = 'DIMMED'
+}
+
+export const MappedStyles = {
+  [SquareStatus.NORMAL]: '',
+  [SquareStatus.HIGHLIGHT]: 'animate-spin-vertical',
+  [SquareStatus.DIMMED]: 'bg-opacity-50'
+}
 
 interface SquareProps {
   position: [number, number]
   value: SymbolMarker
+  status: SquareStatus
   enabled: boolean
   onClick: () => void
 }
@@ -59,7 +73,7 @@ function Square(props: SquareProps) {
   return (
     <div
       onClick={handleClick}
-      className={`w-16 h-16 flex justify-self-center items-center justify-center text-6xl font-bold cursor-pointer ${
+      className={`${MappedStyles[props.status]} w-16 h-16 flex justify-self-center items-center justify-center text-6xl font-bold cursor-pointer ${
         hovered
           ? `${bgColor} text-white`
           : `${squareBgColor} ${squareFontColor}`


### PR DESCRIPTION
## Feature

Implement feature to highlight winning positions.

- when a player wins, the winning squares are animated and spinning on its vertical axis.
- when a player draws, the squares are dimmed by setting the background opacity  to 50%

This closes #1 

## Screenshots

![image](https://github.com/pixelbits-mk/tictactoe/assets/7643369/a03955ee-93e3-410b-b145-d942ae6cdca3)
